### PR TITLE
Rename PtyProxy to PtyShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For example, add src/main.rs as following:
 extern crate pty;
 extern crate pty_shell;
 
-use pty_shell::{winsize, PtyProxy, PtyHandler};
+use pty_shell::{winsize, PtyShell, PtyHandler};
 
 struct Shell;
 impl PtyHandler for Shell {


### PR DESCRIPTION
`exec`, a part of this trait, have no relation to `proxy`.
