### PR TITLE
Fix compile error on newer rusts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub trait PtyHandler {
 
 pub trait PtyShell {
     fn exec<S: AsRef<str>>(&self, shell: S) -> Result<()>;
-    fn proxy<H: PtyHandler>(&self, handler: H) -> Result<()>;
+    fn proxy<H: PtyHandler + 'static>(&self, handler: H) -> Result<()>;
 }
 
 impl PtyShell for tty::Fork {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/18937 and related issues
for upstream discussion.

Compiling the previous code on modern rust results in:
error[E0276]: impl has stricter requirements than trait

This is the most trivial way to fix this issue.

A better fix might be possible. If the event loop were to migrate to
tokio and be external to the library (as hyper does these days), that
would allow expressing a more stringent lifetime on the handler.

For now, getting it back to a compiling state seems like a good step.